### PR TITLE
Finished projects

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -122,7 +122,7 @@ html, body {
 }
 
 #project-list {
-  .project {
+  .project, .finished-project {
     .name {
       font-weight: bold;
       font-size: 1.1em;
@@ -138,6 +138,9 @@ html, body {
 
       float: right;
     }
+  }
+  .finished-project {
+    background-color: lightgray;
   }
 }
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -4,7 +4,9 @@ class ProjectsController < ApplicationController
   before_filter :verify_project_creator, only: [:destroy]
 
   def index
-    @projects = tagged_projects.order(updated_at: :asc)
+    @projects = tagged_projects.where(finished: false).order(updated_at: :asc)
+    @finished_projects =
+      tagged_projects.where(finished: true).order(updated_at: :asc)
     @top_tags = ActsAsTaggableOn::Tag.most_used(10)
     @tags_used = Array(params[:tag])
   end

--- a/app/views/projects/index.html.slim
+++ b/app/views/projects/index.html.slim
@@ -54,6 +54,12 @@
                 .name = project.name.titlecase
                 .description = truncate(project.description, length: 300, omission: "...")
 
-            - if @projects.empty?
+            - @finished_projects.each do |project|
+              = link_to project, class: "list-group-item finished-project" do
+                .contributors #{project.people.count} contributors
+                .name = project.name.titlecase + " (finished, yay!)"
+                .description = truncate(project.description, length: 300, omission: "...")
+
+            - if @projects.empty? && @finished_projects.empty?
               li.list-group-item
                 div Sorry, We couldn't find any projects matching your criteria!

--- a/app/views/projects/show.html.slim
+++ b/app/views/projects/show.html.slim
@@ -8,6 +8,8 @@
       .row
         .col-sm-12
           h1 = @project.name.titlecase
+          - if @project.finished == true
+            h3 = "Finished, yay!"
           .panel.panel-primary.project-content
             .panel-body
               p = @project.description

--- a/db/migrate/20150206131046_add_finished_to_projects.rb
+++ b/db/migrate/20150206131046_add_finished_to_projects.rb
@@ -1,0 +1,6 @@
+class AddFinishedToProjects < ActiveRecord::Migration
+  def change
+    add_column :projects, :finished, :boolean, :default => false
+    add_index  :projects, :finished
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150124232923) do
+ActiveRecord::Schema.define(version: 20150206131046) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -79,7 +79,10 @@ ActiveRecord::Schema.define(version: 20150124232923) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.json     "urls",        default: []
+    t.boolean  "finished",    default: false
   end
+
+  add_index "projects", ["finished"], name: "index_projects_on_finished", using: :btree
 
   create_table "taggings", force: true do |t|
     t.integer  "tag_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,7 +7,7 @@ projects = []
 people = []
 users = []
 
-5.times do
+6.times do
   projects << FactoryGirl.create(:project)
 end
 
@@ -46,3 +46,6 @@ projects[4].people << people[4]
 projects[4].tag_list.add("website")
 projects[4].tag_list.add("computer")
 projects[4].save
+
+projects[5].finished = true
+projects[5].save

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -58,6 +58,23 @@ RSpec.describe ProjectsController, :type => :controller do
       get :show, id: project1.id
       expect(response.body).to include(person.name)
     end
+
+    it "does not show 'Finished, yay!' for an unfinished project" do
+      get :show, id: project1.id
+      expect(response.body).to_not include("Finished, yay!")
+    end
+
+    context "finished project" do
+      before(:each) do
+        project1.finished = true
+        project1.save!
+      end
+
+      it "shows 'Finished, yay!' for a finished project" do
+        get :show, id: project1.id
+        expect(response.body).to include("Finished, yay!")
+      end
+    end
   end
 
   describe "GET 'New'" do


### PR DESCRIPTION
This is a simple hack that allows projects to be marked as finished. However, it does not yet include a way to non-programmatically set a project as finished (ie, one cannot merely go to a project's edit page and set it to finished). I thought I'd wait until I have the creds to log in in dev before adding that ability. Or someone else could do it.
