### PR TITLE
fixed the apostrophies issue in #43

### DIFF
--- a/app/views/projects/index.html.slim
+++ b/app/views/projects/index.html.slim
@@ -52,7 +52,7 @@
               = link_to project, class: "list-group-item project" do
                 .contributors #{project.people.count} contributors
                 .name = project.name.titlecase
-                .description == truncate(strip_tags(project.markdown), length: 300, omission: "...")
+                .description == truncate(strip_tags(project.markdown), length: 300, omission: "...", escape: false)
 
             - if @projects.empty?
               li.list-group-item


### PR DESCRIPTION
The `truncate` method isn't HTML safe as it is, so adding the escape attribute solved the problem.

Tested it locally, everything seems to be OK as far as the apostrophes is concerned. 