### PR TITLE
Fix @events bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,8 +45,10 @@ gem 'nokogiri'
 gem 'icalendar'
 
 group :development do
-  gem 'spring-commands-rspec'
+  gem 'better_errors'
+  gem 'binding_of_caller'
   gem 'pry-rails'
+  gem 'spring-commands-rspec'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,12 @@ GEM
       json
     bcrypt (3.1.10)
     bcrypt (3.1.10-x86-mingw32)
+    better_errors (2.1.1)
+      coderay (>= 1.0.0)
+      erubis (>= 2.6.6)
+      rack (>= 0.9.0)
+    binding_of_caller (0.7.2)
+      debug_inspector (>= 0.0.1)
     bootstrap-sass (3.3.5)
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.2.19)
@@ -49,6 +55,7 @@ GEM
     css_parser (1.3.6)
       addressable
     database_cleaner (1.4.1)
+    debug_inspector (0.0.2)
     devise (3.5.2)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -238,6 +245,8 @@ PLATFORMS
 DEPENDENCIES
   acts-as-taggable-on (~> 3.4)
   acts_as_commentable
+  better_errors
+  binding_of_caller
   bootstrap-sass
   database_cleaner
   devise

--- a/app/views/welcome/index.html.slim
+++ b/app/views/welcome/index.html.slim
@@ -21,22 +21,25 @@
             .panel-heading
               h2.panel-title Our Next Event
             .panel-body
-              h4 = @event.title.titleize
-              hr
-              p
-                strong When:
-                '  #{@event.start_at.to_s(:event)}
-              p
-                strong Until:
-                '  #{@event.end_at.to_s(:event)}
-              p
-                strong Where:
-                '
-                span = link_to @event.location, "https://maps.google.com?q=#{@event.location}", target: "_blank"
-              p = @event.description.truncate(250)
-              .clearfix
-                .pull-left: p = link_to 'Learn More', @event.url, target: "_blank"
-                .pull-right: p = link_to 'All Events (Meetup)', "http://www.meetup.com/codeforatlanta", target: "_blank"
+              - if @event
+                h4 = @event.title.titleize
+                hr
+                p
+                  strong When:
+                  '  #{@event.start_at.to_s(:event)}
+                p
+                  strong Until:
+                  '  #{@event.end_at.to_s(:event)}
+                p
+                  strong Where:
+                  '
+                  span = link_to @event.location, "https://maps.google.com?q=#{@event.location}", target: "_blank"
+                p = @event.description.truncate(250)
+                .clearfix
+                  .pull-left: p = link_to 'Learn More', @event.url, target: "_blank"
+                  .pull-right: p = link_to 'All Events (Meetup)', "http://www.meetup.com/codeforatlanta", target: "_blank"
+              - else
+                h4 = 'No Events Posted'
     .col-sm-8
       .row
 


### PR DESCRIPTION
### Problem
When loading the main page in my local dev environment, I had no events for the future, which caused the page to crash.

### Cause
It crashed because of the line `@events.title`. The method `title` could not be called on `nil`.

### Solution
If `@events` is `nil` it will now show 'No Events Posted.'
I also added the gem 'better errors' to help with debugging.